### PR TITLE
Add an example to play chords using PyChord

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## TBD
+## Forthcoming
+
+- Add example to integrate with [PyChord](https://github.com/yuma-m/pychord).
 
 ## 0.2.0
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ $ pip install pyaudio
 >>> player.play_wave(synthesizer.generate_chord(chord, 3.0))
 ```
 
+You can use [PyChord](https://github.com/yuma-m/pychord) to handle chords easily.
+
+```python
+>>> from pychord import Chord
+>>> chord = Chord("Dm7/G")
+>>> player.play_wave(synthesizer.generate_chord(chord.components_with_pitch(root_pitch=3), 3.0))
+```
+
 ### Specify audio device
 
 ```python
@@ -71,6 +79,17 @@ $ pip install pyaudio
 >>> chord = ["C4", "E4", "G4"]
 >>> wave = synthesizer.generate_chord(chord, 3.0)
 >>> writer.write_wave("path/to/your.wav", wave)
+```
+
+## Examples
+
+### play_pychord.py
+
+Play chords using [PyChord](https://github.com/yuma-m/pychord).
+
+```bash
+pip install pychord>=0.5.0
+python example/play_pychord.py A C#m7 DM7 Bm7/E A
 ```
 
 ## Supported OS

--- a/example/play_pychord.py
+++ b/example/play_pychord.py
@@ -1,0 +1,31 @@
+# In this demo, the chords passed as arguments will be played.
+
+import argparse
+
+from pychord import ChordProgression
+
+from synthesizer import Player, Synthesizer, Waveform
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("chord", nargs="+", help="The chord to be played")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    chords = ChordProgression(args.chord)
+
+    player = Player()
+    player.open_stream()
+    synthesizer = Synthesizer(osc1_waveform=Waveform.triangle, osc1_volume=1.0, use_osc2=False)
+
+    for chord in chords:
+        notes = chord.components_with_pitch(root_pitch=3)
+        print("Play {}".format(chord))
+        player.play_wave(synthesizer.generate_chord(notes, 1.0))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- Add an example to handle and play chord easily using [PyChord](https://github.com/yuma-m/pychord).
- This example requires [Chord.components_with_pitch method](https://github.com/yuma-m/pychord/pull/45) supported in pychord>=0.5.0.